### PR TITLE
Improve logging of API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for DS API rubygem
 
+## 1.3.2 - 2022-04-01
+
+- (Ian) Remove use of automated Faraday logging of API calls. Add manual
+  logging of API calls, to conform to local best practice
+
 ## 1.3.1 - 2022-03-28
 
 - (Ian) Add duration to reported ActiveSupport::Notification of API response

--- a/fixtures/vcr_cassettes/test_0004_should_retrieve_JSON_with_HTTP_GET.yml
+++ b/fixtures/vcr_cassettes/test_0004_should_retrieve_JSON_with_HTTP_GET.yml
@@ -36,4 +36,40 @@ http_interactions:
       encoding: UTF-8
       string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
   recorded_at: Thu, 27 Jan 2022 11:25:30 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: http://localhost:8888/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - d8c1580395a08f93
+      Sleuth-Span-Id:
+      - d8c1580395a08f93
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Fri, 01 Apr 2022 15:48:30 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Fri, 01 Apr 2022 15:48:30 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/test_0005_should_instrument_an_API_call.yml
+++ b/fixtures/vcr_cassettes/test_0005_should_instrument_an_API_call.yml
@@ -36,4 +36,40 @@ http_interactions:
       encoding: UTF-8
       string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
   recorded_at: Thu, 27 Jan 2022 11:44:53 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: http://localhost:8888/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - c862239b70dc8c5f
+      Sleuth-Span-Id:
+      - c862239b70dc8c5f
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Fri, 01 Apr 2022 15:48:30 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Fri, 01 Apr 2022 15:48:31 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/test_0007_should_instrument_a_failed_API_call.yml
+++ b/fixtures/vcr_cassettes/test_0007_should_instrument_a_failed_API_call.yml
@@ -92,4 +92,50 @@ http_interactions:
           "path" : "/ceci/nest/pas/une/page"
         }
   recorded_at: Fri, 28 Jan 2022 15:09:22 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: http://localhost:8888/ceci/nest/pas/une/page?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - a3a55a831158c2c3
+      Sleuth-Span-Id:
+      - a3a55a831158c2c3
+      Vary:
+      - Accept
+      - Access-Control-Request-Headers
+      - Access-Control-Request-Method
+      - Origin
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '183'
+      Date:
+      - Fri, 01 Apr 2022 15:48:30 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "timestamp" : "Fri Apr 01 15:48:30 GMT 2022",
+          "status" : "404",
+          "error" : "Not Found",
+          "message" : "Requested endpoint doesn't exist",
+          "path" : "/ceci/nest/pas/une/page"
+        }
+  recorded_at: Fri, 01 Apr 2022 15:48:30 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/test_0008_should_log_the_call_to_the_data_API.yml
+++ b/fixtures/vcr_cassettes/test_0008_should_log_the_call_to_the_data_API.yml
@@ -36,4 +36,40 @@ http_interactions:
       encoding: UTF-8
       string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
   recorded_at: Thu, 27 Jan 2022 18:49:22 GMT
-recorded_with: VCR 6.0.0
+- request:
+    method: get
+    uri: http://localhost:8888/landregistry/id/ukhpi?_limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Sleuth-Trace-Id:
+      - 06ffa5932289460b
+      Sleuth-Span-Id:
+      - 06ffa5932289460b
+      Vary:
+      - Accept
+      Cache-Control:
+      - max-age=0
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1771'
+      Date:
+      - Fri, 01 Apr 2022 15:48:30 GMT
+    body:
+      encoding: UTF-8
+      string: '{"meta":{"@id":"http://localhost//landregistry/id/ukhpi?_limit=1","publisher":"","license":"","licenseName":"","comment":"","version":"0.1","hasFormat":["http://localhost//landregistry/id/ukhpi.html?_limit=1","http://localhost//landregistry/id/ukhpi.geojson?_limit=1","http://localhost//landregistry/id/ukhpi.rdf?_limit=1","http://localhost//landregistry/id/ukhpi.json?_limit=1","http://localhost//landregistry/id/ukhpi.csv?_limit=1","http://localhost//landregistry/id/ukhpi.ttl?_limit=1"],"limit":1},"items":[{"@id":"http://landregistry.data.gov.uk/data/ukhpi/region/rutland/month/1999-05","refRegion":{"@id":"http://landregistry.data.gov.uk/id/region/rutland"},"refMonth":"1999-05","averagePrice":86936,"housePriceIndex":34.68,"percentageAnnualChange":7.75,"percentageChange":3.35,"salesVolume":77,"averagePriceDetached":118808,"housePriceIndexDetached":35.49,"percentageChangeDetached":3.21,"percentageAnnualChangeDetached":7.56,"averagePriceSemiDetached":71348,"housePriceIndexSemiDetached":34.29,"percentageChangeSemiDetached":3.42,"percentageAnnualChangeSemiDetached":7.91,"averagePriceTerraced":61817,"housePriceIndexTerraced":33.79,"percentageChangeTerraced":3.60,"percentageAnnualChangeTerraced":7.55,"averagePriceFlatMaisonette":42370,"housePriceIndexFlatMaisonette":34.70,"percentageChangeFlatMaisonette":3.61,"percentageAnnualChangeFlatMaisonette":9.47,"averagePriceNewBuild":99439,"housePriceIndexNewBuild":33.50,"percentageChangeNewBuild":3.17,"percentageAnnualChangeNewBuild":8.12,"salesVolumeNewBuild":21,"averagePriceExistingProperty":85036,"housePriceIndexExistingProperty":34.89,"percentageChangeExistingProperty":3.38,"percentageAnnualChangeExistingProperty":7.88,"salesVolumeExistingProperty":56,"refPeriodStart":"1999-05-01","refPeriodDuration":1}]}'
+  recorded_at: Fri, 01 Apr 2022 15:48:30 GMT
+recorded_with: VCR 6.1.0

--- a/lib/data_services_api/version.rb
+++ b/lib/data_services_api/version.rb
@@ -4,6 +4,6 @@
 module DataServicesApi
   MAJOR = 1
   MINOR = 3
-  PATCH = 1
+  PATCH = 2
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end

--- a/test/data_services_api/dataset_test.rb
+++ b/test/data_services_api/dataset_test.rb
@@ -6,7 +6,11 @@ describe 'DataServiceApi::Dataset' do
   before do
     VCR.insert_cassette name, record: :new_episodes
     api_url = ENV['API_URL'] || 'http://localhost:8888'
-    @dataset = DataServicesApi::Service.new(url: api_url).dataset('ukhpi')
+
+    mock_logger = mock('logger')
+    mock_logger.expects(:info).at_least(0)
+
+    @dataset = DataServicesApi::Service.new(url: api_url, logger: mock_logger).dataset('ukhpi')
   end
 
   after do


### PR DESCRIPTION
epimorphics/hmlr-linked-data#85

This commit removes the use of automated Faraday logging of remote API
calls. The issue is that Faraday does not log the API requests in a way
that matches our local best practice.

Instead, we manually log the API call **after** it has completed. That
way, we can associate the HTTP URL with the return status and call
duration, in one single log line.
