### PR TITLE
Resolve Casing Mismatch on message string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - (Jon) Now handles matching the message flag while ignoring the casing of the message
 - (Jon) Better handling of reporting different logging levels using DRY principles
+- (Jon) Resolves failing test for duration as integer
 
 ## 1.4.0 - 2023-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.4.1 - 2023-06-23
 
-- (Jon) Better handling of reporting different logging levels using DRY principles
 - (Jon) Now handles matching the message flag while ignoring the casing of the message
+- (Jon) Better handling of reporting different logging levels using DRY principles
 
 ## 1.4.0 - 2023-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for DS API rubygem
 
+## 1.4.1 - 2023-06-23
+
+- (Jon) Better handling of reporting different logging levels using DRY principles
+- (Jon) Now handles matching the message flag while ignoring the casing of the message
+
 ## 1.4.0 - 2023-06-21
 
 - (Jon) New and improved logging on the service level

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -184,7 +184,7 @@ module DataServicesApi
       defined?(Rails)
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists, Metrics/AbcSize
     # Log the API response with the appropriate log level
     # @param [Faraday::Response] response - The response object
     # @param [Float] start_time - The time the request was sent
@@ -211,7 +211,7 @@ module DataServicesApi
       # add the request url and elapsed time to the message if it's the default message
       if message.casecmp?('Completed')
         message = "#{message.capitalize} #{request_url}, time taken #{format('%.0f μs',
-                                                                  elapsed_time)}"
+                                                                             elapsed_time)}"
       end
 
       log_fields = {
@@ -221,7 +221,7 @@ module DataServicesApi
         message: message
       }
 
-    # Log the API responses at the appropriate level requested
+      # Log the API responses at the appropriate level requested
       case log_type
       when 'error'
         logger.error(JSON.generate(log_fields))
@@ -233,6 +233,6 @@ module DataServicesApi
         logger.info(JSON.generate(log_fields))
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists, Metrics/AbcSize
   end
 end

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -196,7 +196,7 @@ module DataServicesApi
     def log_api_response(
       response,
       start_time,
-      message = 'completed',
+      message = 'Completed',
       status = nil,
       request_url = nil,
       log_type = 'info'
@@ -209,9 +209,9 @@ module DataServicesApi
       # calculate the elapsed time
       elapsed_time = end_time - start_time
       # add the request url and elapsed time to the message if it's the default message
-      if message.casecmp?('Completed')
-        message = "#{message.capitalize} #{request_url}, time taken #{format('%.0f μs',
-                                                                             elapsed_time)}"
+      if message  == 'Completed'
+        message = "#{message} Data Services API request,
+                  time taken #{format('%.0f μs', elapsed_time)}"
       end
 
       log_fields = {

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -209,8 +209,8 @@ module DataServicesApi
       # calculate the elapsed time
       elapsed_time = end_time - start_time
       # add the request url and elapsed time to the message if it's the default message
-      if message == 'Completed'
-        message = "#{message} #{request_url}, time taken #{format('%.0f μs',
+      if message.casecmp?('Completed')
+        message = "#{message.capitalize} #{request_url}, time taken #{format('%.0f μs',
                                                                   elapsed_time)}"
       end
 

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -214,54 +214,25 @@ module DataServicesApi
                                                                   elapsed_time)}"
       end
 
+      log_fields = {
+        request_url: request_url,
+        status: status,
+        duration: elapsed_time,
+        message: message
+      }
+
+    # Log the API responses at the appropriate level requested
       case log_type
       when 'error'
-        log_error(
-          request_url: request_url,
-          status: status,
-          duration: elapsed_time,
-          message: message
-        )
+        logger.error(JSON.generate(log_fields))
       when 'warn'
-        log_warn(
-          request_url: request_url,
-          status: status,
-          duration: elapsed_time,
-          message: message
-        )
+        logger.warn(JSON.generate(log_fields))
       when 'debug'
-        log_debug(
-          request_url: request_url,
-          status: status,
-          duration: elapsed_time,
-          message: message
-        )
+        logger.debug(JSON.generate(log_fields))
       else
-        log_info(
-          request_url: request_url,
-          status: status,
-          duration: elapsed_time,
-          message: message
-        )
+        logger.info(JSON.generate(log_fields))
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/ParameterLists
-
-    # These helper methods log the API responses at the appropriate level requested
-    def log_info(info)
-      logger.info(info)
-    end
-
-    def log_warn(warn)
-      logger.warn(warn)
-    end
-
-    def log_error(error)
-      logger.error(error)
-    end
-
-    def log_debug(debug)
-      logger.debug(debug)
-    end
   end
 end

--- a/lib/data_services_api/version.rb
+++ b/lib/data_services_api/version.rb
@@ -4,7 +4,7 @@
 module DataServicesApi
   MAJOR = 1
   MINOR = 4
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/test/data_services_api/service_test.rb
+++ b/test/data_services_api/service_test.rb
@@ -141,9 +141,11 @@ describe 'DataServicesAPI::Service', vcr: true do
 
     json = msg_log.first
 
-    _(json).wont_be_nil
-    _(json[:duration]).wont_be_nil
-    _(json[:duration]).must_be :>, 0
-    assert_kind_of(Integer, json[:duration])
+    duration = JSON.parse(json)['duration']
+
+    _(duration).wont_be_nil
+    _(duration).wont_be_nil
+    _(duration).must_be :>, 0
+    assert_kind_of(Integer, duration)
   end
 end


### PR DESCRIPTION
This PR resolves incorrectly NOT matching the message flag by ignoring the casing of the message

## Additional Changes

- Better handling of reporting different logging levels using DRY principles