### PR TITLE
Issue: x-request-id propagation not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,25 @@
 # Changelog for DS API rubygem
 
-## 1.5.0 - 2023-06-23
+## 1.5.1 - 2024-10-14
+
+- (Jon) Fixed casing on the `X-Request-Id` header for SAPINT requests to match
+  the header received from the apps using the gem.
+  [GH-189](https://github.com/epimorphics/hmlr-ansible-deployment/issues/189)
+- (Jon) Updated the previously supplied release date in the `v1.5.0` entry to
+  match the actual release date.
+- (Jon) Updated the `version.rb` `SUFFIX` entry to be `nil` by default to ensure
+  the version number is correctly formatted.
+
+## 1.5.0 - 2024-10-09
 
 - (Dan) Updates ruby to 2.7.8 and version cadence to 1.5.0
 
 ## 1.4.1 - 2023-06-23
 
-- (Jon) Now handles matching the message flag while ignoring the casing of the message
-- (Jon) Better handling of reporting different logging levels using DRY principles
+- (Jon) Now handles matching the message flag while ignoring the casing of the
+  message
+- (Jon) Better handling of reporting different logging levels using DRY
+  principles
 - (Jon) Resolves failing test for duration as integer
 
 ## 1.4.0 - 2023-06-21
@@ -40,7 +52,8 @@
   to the system logs.
 - (Jon) As part of the better logging updates the error message returned to the
   requesting app has been refactored to be more concise as well the failed
-  connection error status has been set specifically to `503 Service Unavailable`.
+  connection error status has been set specifically to `503 Service
+  Unavailable`.
 
 ## 1.3.2 - 2022-04-01
 

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -47,7 +47,7 @@ module DataServicesApi
       conn = set_connection_timeout(create_http_connection(http_url))
 
       response = conn.get do |req|
-        req.headers['X-Request-ID'] = Thread.current[:request_id] if Thread.current[:request_id]
+        req.headers['X-Request-Id'] = Thread.current[:request_id] if Thread.current[:request_id]
         req.headers['Accept'] = accept_headers
         req.options.params_encoder = Faraday::FlatParamsEncoder
         req.params = params.merge(options)
@@ -91,7 +91,7 @@ module DataServicesApi
       conn = set_connection_timeout(create_http_connection(http_url))
 
       response = conn.post do |req|
-        req.headers['X-Request-ID'] = Thread.current[:request_id] if Thread.current[:request_id]
+        req.headers['X-Request-Id'] = Thread.current[:request_id] if Thread.current[:request_id]
         req.headers['Accept'] = 'application/json'
         req.headers['Content-Type'] = 'application/json'
         req.body = json

--- a/lib/data_services_api/version.rb
+++ b/lib/data_services_api/version.rb
@@ -4,7 +4,7 @@
 module DataServicesApi
   MAJOR = 1
   MINOR = 5
-  PATCH = 0
+  PATCH = 1
   SUFFIX = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/lib/data_services_api/version.rb
+++ b/lib/data_services_api/version.rb
@@ -5,6 +5,6 @@ module DataServicesApi
   MAJOR = 1
   MINOR = 5
   PATCH = 1
-  SUFFIX = 0
+  SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR resolves ticket [189](https://github.com/epimorphics/hmlr-ansible-deployment/issues/189)

- Fixed casing on the `X-Request-Id` header for SAPINT requests to match the header received from the apps using the gem.
- Updated the previously supplied release date in the `v1.5.0` entry to match the actual release date.
- Updated the `version.rb` `SUFFIX` entry to be `nil` by default to ensure the gem version number is correctly formatted.