### PR TITLE
Spike: Improved log message handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.2 - 2025-02
 
+- (Jon) Included the HTTP method in the response log.
+- (Jon) Set a default method value of 'GET' if not provided.
+- (Jon) Ensured logs are sorted and cleaned up before final output.
 - (Jon) Updated the instrumenter calls to include exceptions as a keyword
   argument for better clarity and consistency.
   [GH-465](https://github.com/epimorphics/ukhpi/issues/465)

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -52,6 +52,7 @@ module DataServicesApi
                                             source: URI.parse(http_url).path.split('/').last,
                                             timer: elapsed_time
                                           }),
+        method: response.env.method.upcase,
         path: URI.parse(http_url).path,
         query_string: query_string,
         request_status: 'processing',
@@ -262,6 +263,7 @@ module DataServicesApi
       duration = (end_time - start_time) / 1000 if start_time
       # parse out the optional parameters and set defaults
       log_fields[:message] ||= log_fields[:response]&.body
+      log_fields[:method] ||= 'GET'
       log_fields[:request_time] ||= duration
       log_fields[:request_status] ||= 'completed' if log_fields[:status] == 200
       log_fields[:start_time] = nil
@@ -269,6 +271,8 @@ module DataServicesApi
 
       # Clear out nil values from the log fields
       logs = log_fields.compact
+
+      logs.sort.to_h
       # Log the API responses at the appropriate level requested
       case log_type
       when 'error'


### PR DESCRIPTION
This PR contains changes to coincide with other improvements in JSON Rails Logger gem alongside further improvements in the UKHPI application.

- Included the HTTP method in response logs.
- Set default method value to 'GET' if not specified.
- Sorted and cleaned up logs before final output.