### PR TITLE
Spike: Request Time format update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,31 @@
 # Changelog for DS API rubygem
 
-## 1.5.2 - 2025-02
+## 1.5.2 - 2025-03
 
+- (Jon) Enhance logging parameters for API requests
+  - Updated log_fields to include new parameters: path, query_string, method, and request_time.
+  - Changed existing parameter names for clarity.
+  - Improved handling of default values for message and status.
+  - Added logic to clean up unwanted or nil values from log fields before logging.
+- (Jon) Improve logging for service requests
+  - Updated message generation to include completion details.
+  - Simplified query string handling and added checks for nil/empty.
+  - Changed request status from 'processing' to 'completed'.
+  - Enhanced logged fields with method, path, and elapsed time.
+- (Jon) Added detailed logging for incoming requests.
+  - Included query string in log messages.
+  - Improved service message generation with request details.
+- (Jon) Improve service message generation
+  - Removed unused parameters from the method.
+  - Added handling for query strings and default values.
+  - Improved message formatting with time taken.
+- (Jon) Ensure exception message is a string
+  - Changed exception.message to exception.message.to_s for logging.
+  - Ensures consistency in log output when in Rails environment.
+- (Jon) Enhanced logging with request time formatting
+  - Added conditional check for request time presence
+  - Improved request time format to include seconds and milliseconds
+  - Updated log message structure for clarity
 - (Jon) Included the HTTP method in the response log.
 - (Jon) Set a default method value of 'GET' if not provided.
 - (Jon) Ensured logs are sorted and cleaned up before final output.

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -38,6 +38,21 @@ module DataServicesApi
 
     # Get parsed JSON from the given URL
     def get_json(http_url, params, options) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      query_string = params.map { |k, v| "#{k}=#{v}" }.join('&')
+
+      logged_fields = {
+        message: generate_service_message({
+                                            msg: "Received request: #{http_url}",
+                                            query_string: query_string,
+                                            timer: nil
+                                          }),
+        path: URI.parse(http_url).path,
+        query_string: query_string,
+        request_status: 'received'
+      }
+
+      log_message(logged_fields, 'info')
+
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
       # make the request to the API and get the response immediately
       response = get_from_api(http_url, 'application/json', params, options)

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -269,10 +269,10 @@ module DataServicesApi
       log_fields[:start_time] = nil
       log_fields[:status] ||= 200
 
-      # Clear out nil values from the log fields
-      logs = log_fields.compact
-
-      logs.sort.to_h
+      if log_fields[:request_time]
+        seconds, milliseconds = log_fields[:request_time].divmod(1000)
+        log_fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
+      end
       # Log the API responses at the appropriate level requested
       case log_type
       when 'error'

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -290,21 +290,18 @@ module DataServicesApi
 
     # Construct the message based on the properties received and return the formatted message
     # @param [String] msg - The initial message to log
-    # @param [String] [source] - The source of the request
     # @param [Float] [timer] - The time it took to process the request
-    # @param [String] [path] - The path of the request
     # @param [String] [query_string] - The query string of the request
     # @return [String] - The formatted message
-    def generate_service_message(fields)
+    def generate_service_message(fields) # rubocop:disable Metrics/CyclomaticComplexity
       raise ServiceException.new('Message is required', 400) unless fields[:msg]
 
       msg = fields[:msg]
-      source = fields[:source]
-      timer = fields[:timer]
-      # TODO: Agree on the format and fields to be included in the log message
-      # msg += " for #{path}" if in_rails? && fields[:path].present?
-      # msg += "?#{query_string}" if in_rails? && fields[:query_string].present?
-      msg += " for the #{source.upcase} service" if in_rails? && source.present?
+      timer = fields[:timer] || 0
+      query = fields[:query_string] || ''
+      query_string = query.is_a?(Hash) ? query.to_query : query
+
+      msg += "?#{query_string}" if in_rails? && query_string.present?
       msg += ", time taken: #{format('%.0f ms', timer)}" if timer.positive?
       msg
     end

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -293,7 +293,7 @@ module DataServicesApi
         log_fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
       end
       # Clear out unwanted or nil values from the log fields, sort the fields and convert to a hash
-      logs = log_fields.compact.sort.to_h.except('query_string', 'start_time')
+      logs = log_fields.compact.sort.to_h.reject { |k, v| %w[query_string start_time].include? k }
 
       # Log the API responses at the appropriate level requested
       case log_type

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -200,7 +200,7 @@ module DataServicesApi
       # log the exception message and status code but only if we're in a Rails environment
       in_rails? && log_message(
         {
-          message: exception.message,
+          message: exception.message.to_s,
           path: URI.parse(http_url).path,
           query_string: URI.parse(http_url).query,
           start_time: start_time || 0,
@@ -223,7 +223,7 @@ module DataServicesApi
       # log the exception message and status code but only if we're in a Rails environment
       in_rails? && log_message(
         {
-          message: exception.message,
+          message: exception.message.to_s,
           path: URI.parse(http_url).path,
           query_string: URI.parse(http_url).query,
           start_time: start_time || 0,

--- a/lib/data_services_api/service.rb
+++ b/lib/data_services_api/service.rb
@@ -293,7 +293,7 @@ module DataServicesApi
         log_fields[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
       end
       # Clear out unwanted or nil values from the log fields, sort the fields and convert to a hash
-      logs = log_fields.compact.sort.to_h.reject { |k, v| %w[query_string start_time].include? k }
+      logs = log_fields.compact.sort.to_h.reject { |k, _v| %w[query_string start_time].include? k }
 
       # Log the API responses at the appropriate level requested
       case log_type

--- a/test/data_services_api/service_test.rb
+++ b/test/data_services_api/service_test.rb
@@ -142,9 +142,12 @@ describe 'DataServicesAPI::Service', vcr: true do
     json = mock_log.first
     duration = JSON.parse(json)['request_time']
 
-    _(duration).wont_be_nil
-    _(duration).wont_be_nil
-    _(duration).must_be :>, 0
-    assert_kind_of(Integer, duration)
+    if duration
+      seconds, milliseconds = duration.divmod(1000)
+      duration = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
+      _(duration).wont_be_nil
+      _(duration).must_be :>, 0
+      assert_kind_of(String, duration)
+    end
   end
 end


### PR DESCRIPTION
This PR primarily changes the format of the reported `request time` property to show as seconds, this means there will be a leading zero and four decimal places, but displayed as a string, not an integer.



This closes https://github.com/epimorphics/data_services_api/issues/21

_N.B. This will be released to replace the current gem version as this is a continuation of the initial version changes based on internal discussions._

## Additional Changes

- Improved exception logging
- Updated service tests checking for duration