### PR TITLE
Spike: Bump data_services_api version to 1.6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    data_services_api (1.6.0)
+    data_services_api (1.6.1)
       faraday (~> 2.13, >= 2.13.0)
       faraday-encoding (~> 0.0, >= 0.0.6)
       faraday-follow_redirects (~> 0.3, >= 0.3.0)


### PR DESCRIPTION
Missed including the updated the Gemfile.lock in the previous PR.